### PR TITLE
Add Support for Directed Graphs in Subgraph Miner

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -90,7 +90,6 @@ jobs:
               echo 'Running pattern counter...'
               python -m analyze.count_patterns \
                 --dataset=undirected.pkl \
-                --queries_path=results/patterns.pkl \
                 --out_path=results/counts.json \
                 --node_anchored
               echo 'Counting completed.'

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -89,7 +89,7 @@ jobs:
               export PYTHONPATH=/app
               echo 'Running pattern counter...'
               python -m analyze.count_patterns \
-                --dataset=undirected.pkl \
+                --dataset=graph.pkl \
                 --out_path=results/counts.json \
                 --node_anchored
               echo 'Counting completed.'

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -92,6 +92,7 @@ jobs:
                 --dataset=undirected.pkl \
                 --queries_path=results/patterns.pkl \
                 --out_path=results/counts.json \
+                --preserve_labels \
                 --node_anchored
               echo 'Counting completed.'
               ls -la /app/results

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -89,9 +89,8 @@ jobs:
               export PYTHONPATH=/app
               echo 'Running pattern counter...'
               python -m analyze.count_patterns \
-                --dataset=graph.pkl \
-                --queries_path=results/patterns.pkl \
-                --out_path=results/ \
+                --dataset=undirected.pkl \
+                --out_path=results/counts.json \
                 --node_anchored
               echo 'Counting completed.'
               ls -la /app/results

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -90,6 +90,7 @@ jobs:
               echo 'Running pattern counter...'
               python -m analyze.count_patterns \
                 --dataset=undirected.pkl \
+                --queries_path=results/patterns.pkl \
                 --out_path=results/counts.json \
                 --node_anchored
               echo 'Counting completed.'

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -78,25 +78,25 @@ jobs:
               ls -la /app/plots/cluster
               ls -la /app/results
               "
-      # - name: Run pattern counter in Docker container
-      #   run: |
-      #     docker run --rm \
-      #       -v ${{ github.workspace }}:/app \
-      #       -e PYTHONUNBUFFERED=1 \
-      #       decoder-image:latest \
-      #       bash -c "
-      #         set -e
-      #         export PYTHONPATH=/app
-      #         echo 'Running pattern counter...'
-      #         python -m analyze.count_patterns \
-      #           --dataset=graph.pkl \
-      #           --queries_path=results/patterns.pkl \
-      #           --out_path=results/ \
-      #           --node_anchored \
-      #           --preserve_labels
-      #         echo 'Counting completed.'
-      #         ls -la /app/results
-      #       "
+      - name: Run pattern counter in Docker container
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/app \
+            -e PYTHONUNBUFFERED=1 \
+            decoder-image:latest \
+            bash -c "
+              set -e
+              export PYTHONPATH=/app
+              echo 'Running pattern counter...'
+              python -m analyze.count_patterns \
+                --dataset=graph.pkl \
+                --queries_path=results/patterns.pkl \
+                --out_path=results/ \
+                --node_anchored \
+                --preserve_labels
+              echo 'Counting completed.'
+              ls -la /app/results
+            "
 
       - name: Check for generated files
         run: |

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -92,8 +92,7 @@ jobs:
                 --dataset=graph.pkl \
                 --queries_path=results/patterns.pkl \
                 --out_path=results/ \
-                --node_anchored \
-                --preserve_labels
+                --node_anchored
               echo 'Counting completed.'
               ls -la /app/results
             "

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -89,7 +89,7 @@ jobs:
               export PYTHONPATH=/app
               echo 'Running pattern counter...'
               python -m analyze.count_patterns \
-                --dataset=graph.pkl \
+                --dataset=undirected.pkl \
                 --out_path=results/counts.json \
                 --node_anchored
               echo 'Counting completed.'

--- a/analyze/count_patterns.py
+++ b/analyze/count_patterns.py
@@ -1,3 +1,4 @@
+print("Running count_patterns.py...")
 import argparse
 import csv
 import time

--- a/analyze/count_patterns.py
+++ b/analyze/count_patterns.py
@@ -101,7 +101,7 @@ def arg_parse():
     parser = argparse.ArgumentParser(description='count graphlets in a graph')
     parser.add_argument('--dataset', type=str)
     parser.add_argument('--queries_path', type=str)
-    parser.add_argument('--graph_type', type=str, default="undirected")
+    parser.add_argument('--graph_type', type=str)
     parser.add_argument('--out_path', type=str)
     parser.add_argument('--n_workers', type=int)
     parser.add_argument('--count_method', type=str)
@@ -118,6 +118,7 @@ def arg_parse():
                        queries_path="results/out-patterns.p",
                        out_path="results/counts.json",
                        n_workers=4,
+                       graph_type = "undirected",
                        count_method="bin",
                        baseline="none",
                        preserve_labels=False)

--- a/analyze/count_patterns.py
+++ b/analyze/count_patterns.py
@@ -43,6 +43,15 @@ import torch.multiprocessing as mp
 from sklearn.decomposition import PCA
 from itertools import combinations
 
+import argparse
+from subgraph_mining.config import parse_decoder
+from subgraph_matching.config import parse_encoder
+
+parser = argparse.ArgumentParser(description='Decoder arguments')
+parse_encoder(parser)
+parse_decoder(parser)
+args = parser.parse_args()
+
 # Increase timeout for large graphs
 MAX_SEARCH_TIME = 1800  # 30 minutes for large graph processing
 MAX_MATCHES_PER_QUERY = 10000

--- a/analyze/count_patterns.py
+++ b/analyze/count_patterns.py
@@ -198,13 +198,23 @@ def count_graphlets_helper(inp):
                 
                 if preserve_labels:
                     # Use lambda functions to properly match node and edge attributes
-                    matcher = iso.GraphMatcher(target, query,
-                        node_match=lambda n1, n2: (n1.get("anchor") == n2.get("anchor") and
-                                                  n1.get("label") == n2.get("label")),
-                        edge_match=lambda e1, e2: e1.get("type") == e2.get("type"))
+                    if args.graph_type == "directed":
+                        matcher = iso.DiGraphMatcher(target, query,
+                            node_match=lambda n1, n2: (n1.get("anchor") == n2.get("anchor") and
+                                                    n1.get("label") == n2.get("label")),
+                            edge_match=lambda e1, e2: e1.get("type") == e2.get("type"))
+                    else:
+                        matcher = iso.GraphMatcher(target, query,
+                            node_match=lambda n1, n2: (n1.get("anchor") == n2.get("anchor") and
+                                                    n1.get("label") == n2.get("label")),
+                            edge_match=lambda e1, e2: e1.get("type") == e2.get("type"))
                 else:
-                    matcher = iso.GraphMatcher(target, query,
-                        node_match=iso.categorical_node_match(["anchor"], [0]))
+                    if args.graph_type == "directed":
+                        matcher = iso.GraphMatcher(target, query,
+                            node_match=iso.categorical_node_match(["anchor"], [0]))
+                    else:
+                        matcher = iso.GraphMatcher(target, query,
+                            node_match=iso.categorical_node_match(["anchor"], [0]))
                 
                 if time.time() - start_time > timeout:
                     print(f"Timeout on query {i} before isomorphism check")

--- a/analyze/count_patterns.py
+++ b/analyze/count_patterns.py
@@ -50,7 +50,7 @@ from subgraph_matching.config import parse_encoder
 parser = argparse.ArgumentParser(description='Decoder arguments')
 parse_encoder(parser)
 parse_decoder(parser)
-args = parser.parse_args()
+decoder_args = parser.parse_args()
 
 # Increase timeout for large graphs
 MAX_SEARCH_TIME = 1800  # 30 minutes for large graph processing
@@ -69,7 +69,7 @@ def compute_graph_stats(G):
     
     # Add connected components info
     try:
-        if args.graph_type == "directed":
+        if decoder_args.graph_type == "directed":
             stats['n_components'] = nx.number_strongly_connected_components(G)
         else:
             stats['n_components'] = nx.number_connected_components(G)
@@ -127,7 +127,7 @@ def load_networkx_graph(filepath):
     """Load a Networkx graph from pickle format with proper attributes handling."""
     with open(filepath, 'rb') as f:
         data = pickle.load(f)
-        if args.graph_type == "directed":
+        if decoder_args.graph_type == "directed":
             graph = nx.DiGraph()
         else:
             graph = nx.Graph()
@@ -201,7 +201,7 @@ def count_graphlets_helper(inp):
                 
                 if preserve_labels:
                     # Use lambda functions to properly match node and edge attributes
-                    if args.graph_type == "directed":
+                    if decoder_args.graph_type == "directed":
                         matcher = iso.DiGraphMatcher(target, query,
                             node_match=lambda n1, n2: (n1.get("anchor") == n2.get("anchor") and
                                                     n1.get("label") == n2.get("label")),
@@ -212,7 +212,7 @@ def count_graphlets_helper(inp):
                                                     n1.get("label") == n2.get("label")),
                             edge_match=lambda e1, e2: e1.get("type") == e2.get("type"))
                 else:
-                    if args.graph_type == "directed":
+                    if decoder_args.graph_type == "directed":
                         matcher = iso.DiGraphMatcher(target, query,
                             node_match=iso.categorical_node_match(["anchor"], [0]))
                     else:
@@ -300,7 +300,7 @@ def sample_subgraphs(target, n_samples=10, max_size=1000):
         # Start with a random node
         start_node = random.choice(nodes)
         subgraph_nodes = {start_node}
-        if args.graph_type == "directed":
+        if decoder_args.graph_type == "directed":
             frontier = list(target.successors(start_node))
         else:
             frontier = list(target.neighbors(start_node))
@@ -310,7 +310,7 @@ def sample_subgraphs(target, n_samples=10, max_size=1000):
             next_node = frontier.pop(0)
             if next_node not in subgraph_nodes:
                 subgraph_nodes.add(next_node)
-                if args.graph_type == "directed":
+                if decoder_args.graph_type == "directed":
                     frontier.extend([n for n in target.successors(next_node) 
                                     if n not in subgraph_nodes and n not in frontier])
                 else:
@@ -471,7 +471,7 @@ def generate_one_baseline(args):
                 subgraph = graph.subgraph(neigh)
                 if subgraph.number_of_nodes() == 0:
                     continue
-                if args.graph_type == "directed":
+                if decoder_args.graph_type == "directed":
                     largest_cc = max(nx.strongly_connected_components(subgraph), key=len)
                 else:
                     largest_cc = max(nx.connected_components(subgraph), key=len)
@@ -483,14 +483,14 @@ def generate_one_baseline(args):
             elif method == "tree":
                 start_node = random.choice(list(graph.nodes))
                 neigh = [start_node]
-                if args.graph_type == "directed":
+                if decoder_args.graph_type == "directed":
                     frontier = list(set(graph.successors(start_node)) - set(neigh))
                 else:
                     frontier = list(set(graph.neighbors(start_node)) - set(neigh))
                 while len(neigh) < len(query) and frontier:
                     new_node = random.choice(frontier)
                     neigh.append(new_node)
-                    if args.graph_type == "directed":
+                    if decoder_args.graph_type == "directed":
                         frontier += list(graph.successors(new_node))
                     else:
                         frontier += list(graph.neighbors(new_node))

--- a/analyze/count_patterns.py
+++ b/analyze/count_patterns.py
@@ -47,10 +47,9 @@ import argparse
 from subgraph_mining.config import parse_decoder
 from subgraph_matching.config import parse_encoder
 
-parser = argparse.ArgumentParser(description='Decoder arguments')
-parse_encoder(parser)
-parse_decoder(parser)
-decoder_args = parser.parse_args()
+# parser = argparse.ArgumentParser(description='Decoder arguments')
+# parse_decoder(parser)
+# args = parser.parse_args()
 
 # Increase timeout for large graphs
 MAX_SEARCH_TIME = 1800  # 30 minutes for large graph processing
@@ -69,7 +68,7 @@ def compute_graph_stats(G):
     
     # Add connected components info
     try:
-        if decoder_args.graph_type == "directed":
+        if args.graph_type == "directed":
             stats['n_components'] = nx.number_strongly_connected_components(G)
         else:
             stats['n_components'] = nx.number_connected_components(G)
@@ -102,6 +101,7 @@ def arg_parse():
     parser = argparse.ArgumentParser(description='count graphlets in a graph')
     parser.add_argument('--dataset', type=str)
     parser.add_argument('--queries_path', type=str)
+    parser.add_argument('--graph_type', type=str, default="undirected")
     parser.add_argument('--out_path', type=str)
     parser.add_argument('--n_workers', type=int)
     parser.add_argument('--count_method', type=str)
@@ -142,7 +142,7 @@ def load_networkx_graph(filepath):
             
         # If it's a dictionary with graph data
         if isinstance(data, dict):
-            if decoder_args.graph_type == "directed":
+            if args.graph_type == "directed":
                 graph = nx.DiGraph()
             else:
                 graph = nx.Graph()
@@ -212,7 +212,7 @@ def count_graphlets_helper(inp):
                 
                 if preserve_labels:
                     # Use lambda functions to properly match node and edge attributes
-                    if decoder_args.graph_type == "directed":
+                    if args.graph_type == "directed":
                         matcher = iso.DiGraphMatcher(target, query,
                             node_match=lambda n1, n2: (n1.get("anchor") == n2.get("anchor") and
                                                     n1.get("label") == n2.get("label")),
@@ -223,7 +223,7 @@ def count_graphlets_helper(inp):
                                                     n1.get("label") == n2.get("label")),
                             edge_match=lambda e1, e2: e1.get("type") == e2.get("type"))
                 else:
-                    if decoder_args.graph_type == "directed":
+                    if args.graph_type == "directed":
                         matcher = iso.DiGraphMatcher(target, query,
                             node_match=iso.categorical_node_match(["anchor"], [0]))
                     else:
@@ -311,7 +311,7 @@ def sample_subgraphs(target, n_samples=10, max_size=1000):
         # Start with a random node
         start_node = random.choice(nodes)
         subgraph_nodes = {start_node}
-        if decoder_args.graph_type == "directed":
+        if args.graph_type == "directed":
             frontier = list(target.successors(start_node))
         else:
             frontier = list(target.neighbors(start_node))
@@ -321,7 +321,7 @@ def sample_subgraphs(target, n_samples=10, max_size=1000):
             next_node = frontier.pop(0)
             if next_node not in subgraph_nodes:
                 subgraph_nodes.add(next_node)
-                if decoder_args.graph_type == "directed":
+                if args.graph_type == "directed":
                     frontier.extend([n for n in target.successors(next_node) 
                                     if n not in subgraph_nodes and n not in frontier])
                 else:
@@ -482,7 +482,7 @@ def generate_one_baseline(args):
                 subgraph = graph.subgraph(neigh)
                 if subgraph.number_of_nodes() == 0:
                     continue
-                if decoder_args.graph_type == "directed":
+                if args.graph_type == "directed":
                     largest_cc = max(nx.strongly_connected_components(subgraph), key=len)
                 else:
                     largest_cc = max(nx.connected_components(subgraph), key=len)
@@ -494,14 +494,14 @@ def generate_one_baseline(args):
             elif method == "tree":
                 start_node = random.choice(list(graph.nodes))
                 neigh = [start_node]
-                if decoder_args.graph_type == "directed":
+                if args.graph_type == "directed":
                     frontier = list(set(graph.successors(start_node)) - set(neigh))
                 else:
                     frontier = list(set(graph.neighbors(start_node)) - set(neigh))
                 while len(neigh) < len(query) and frontier:
                     new_node = random.choice(frontier)
                     neigh.append(new_node)
-                    if decoder_args.graph_type == "directed":
+                    if args.graph_type == "directed":
                         frontier += list(graph.successors(new_node))
                     else:
                         frontier += list(graph.neighbors(new_node))

--- a/analyze/count_patterns.py
+++ b/analyze/count_patterns.py
@@ -69,7 +69,10 @@ def compute_graph_stats(G):
     
     # Add connected components info
     try:
-        stats['n_components'] = nx.number_connected_components(G)
+        if args.graph_type == "directed":
+            stats['n_components'] = nx.number_strongly_connected_components(G)
+        else:
+            stats['n_components'] = nx.number_connected_components(G)
     except:
         stats['n_components'] = 1  # Assume connected if there's an error
         
@@ -468,7 +471,10 @@ def generate_one_baseline(args):
                 subgraph = graph.subgraph(neigh)
                 if subgraph.number_of_nodes() == 0:
                     continue
-                largest_cc = max(nx.connected_components(subgraph), key=len)
+                if args.graph_type == "directed":
+                    largest_cc = max(nx.strongly_connected_components(subgraph), key=len)
+                else:
+                    largest_cc = max(nx.connected_components(subgraph), key=len)
                 neigh = subgraph.subgraph(largest_cc)
                 neigh = nx.convert_node_labels_to_integers(neigh)
                 if len(neigh) == len(query):

--- a/analyze/count_patterns.py
+++ b/analyze/count_patterns.py
@@ -365,9 +365,9 @@ def count_graphlets(queries, targets, args):
     #changed to multiprocessing using 
     with Pool(processes=args.n_workers) as pool:
 
-        target_stats = pool.map(compute_graph_stats, targets)
+        target_stats = pool.starmap(compute_graph_stats, [(t, args) for t in targets])
         
-        query_stats = pool.map(compute_graph_stats, queries)
+        query_stats = pool.starmap(compute_graph_stats, [(q, args) for q in queries])
     
     # Generate work items with filtering
     inp = []

--- a/analyze/count_patterns.py
+++ b/analyze/count_patterns.py
@@ -213,7 +213,7 @@ def count_graphlets_helper(inp):
                             edge_match=lambda e1, e2: e1.get("type") == e2.get("type"))
                 else:
                     if args.graph_type == "directed":
-                        matcher = iso.GraphMatcher(target, query,
+                        matcher = iso.DiGraphMatcher(target, query,
                             node_match=iso.categorical_node_match(["anchor"], [0]))
                     else:
                         matcher = iso.GraphMatcher(target, query,

--- a/analyze/count_patterns.py
+++ b/analyze/count_patterns.py
@@ -297,15 +297,22 @@ def sample_subgraphs(target, n_samples=10, max_size=1000):
         # Start with a random node
         start_node = random.choice(nodes)
         subgraph_nodes = {start_node}
-        frontier = list(target.neighbors(start_node))
+        if args.graph_type == "directed":
+            frontier = list(target.successors(start_node))
+        else:
+            frontier = list(target.neighbors(start_node))
         
         # Grow the subgraph by BFS
         while len(subgraph_nodes) < max_size and frontier:
             next_node = frontier.pop(0)
             if next_node not in subgraph_nodes:
                 subgraph_nodes.add(next_node)
-                frontier.extend([n for n in target.neighbors(next_node) 
-                              if n not in subgraph_nodes and n not in frontier])
+                if args.graph_type == "directed":
+                    frontier.extend([n for n in target.successors(next_node) 
+                                    if n not in subgraph_nodes and n not in frontier])
+                else:
+                    frontier.extend([n for n in target.neighbors(next_node) 
+                                    if n not in subgraph_nodes and n not in frontier])
         
         sg = target.subgraph(subgraph_nodes)
         subgraphs.append(sg)
@@ -470,11 +477,17 @@ def generate_one_baseline(args):
             elif method == "tree":
                 start_node = random.choice(list(graph.nodes))
                 neigh = [start_node]
-                frontier = list(set(graph.neighbors(start_node)) - set(neigh))
+                if args.graph_type == "directed":
+                    frontier = list(set(graph.successors(start_node)) - set(neigh))
+                else:
+                    frontier = list(set(graph.neighbors(start_node)) - set(neigh))
                 while len(neigh) < len(query) and frontier:
                     new_node = random.choice(frontier)
                     neigh.append(new_node)
-                    frontier += list(graph.neighbors(new_node))
+                    if args.graph_type == "directed":
+                        frontier += list(graph.successors(new_node))
+                    else:
+                        frontier += list(graph.neighbors(new_node))
                     frontier = [x for x in frontier if x not in neigh]
                 if len(neigh) == len(query):
                     sub = graph.subgraph(neigh)

--- a/analyze/count_patterns.py
+++ b/analyze/count_patterns.py
@@ -124,7 +124,10 @@ def load_networkx_graph(filepath):
     """Load a Networkx graph from pickle format with proper attributes handling."""
     with open(filepath, 'rb') as f:
         data = pickle.load(f)
-        graph = nx.Graph()
+        if args.graph_type == "directed":
+            graph = nx.DiGraph()
+        else:
+            graph = nx.Graph()
         
         # Add nodes with their attributes
         for node in data['nodes']:

--- a/analyze/count_patterns.py
+++ b/analyze/count_patterns.py
@@ -477,7 +477,7 @@ def generate_one_baseline(args):
     return nx.Graph()  # Return empty graph if failed
 
 def convert_to_networkx(graph):
-    if isinstance(graph, nx.Graph):
+    if isinstance(graph, nx.Graph) or isinstance(graph, nx.DiGraph):
         return graph
     return pyg_utils.to_networkx(graph).to_undirected()
     

--- a/analyze/count_patterns.py
+++ b/analyze/count_patterns.py
@@ -44,13 +44,7 @@ import torch.multiprocessing as mp
 from sklearn.decomposition import PCA
 from itertools import combinations
 
-# import argparse
-# from subgraph_mining.config import parse_decoder
-# from subgraph_matching.config import parse_encoder
-
-# parser = argparse.ArgumentParser(description='Decoder arguments')
-# parse_decoder(parser)
-# args = parser.parse_args()
+args = None
 
 # Increase timeout for large graphs
 MAX_SEARCH_TIME = 1800  # 30 minutes for large graph processing

--- a/analyze/count_patterns.py
+++ b/analyze/count_patterns.py
@@ -43,9 +43,9 @@ import torch.multiprocessing as mp
 from sklearn.decomposition import PCA
 from itertools import combinations
 
-import argparse
-from subgraph_mining.config import parse_decoder
-from subgraph_matching.config import parse_encoder
+# import argparse
+# from subgraph_mining.config import parse_decoder
+# from subgraph_matching.config import parse_encoder
 
 # parser = argparse.ArgumentParser(description='Decoder arguments')
 # parse_decoder(parser)

--- a/analyze/count_patterns.py
+++ b/analyze/count_patterns.py
@@ -163,7 +163,7 @@ def load_networkx_graph(filepath):
 
 def count_graphlets_helper(inp):
     """Worker function to count pattern occurrences with better timeout handling."""
-    i, query, target, method, node_anchored, anchor_or_none, preserve_labels, timeout = inp
+    i, query, target, method, node_anchored, anchor_or_none, preserve_labels, timeout, args = inp
     
     start_time = time.time()
     
@@ -401,10 +401,10 @@ def count_graphlets(queries, targets, args):
                     
                 for anchor in anchors:
                     inp.append((i, query, target, args.count_method, args.node_anchored, anchor, 
-                             args.preserve_labels, args.timeout))
+                             args.preserve_labels, args.timeout, args))
             else:
                 inp.append((i, query, target, args.count_method, args.node_anchored, None, 
-                         args.preserve_labels, args.timeout))
+                         args.preserve_labels, args.timeout, args))
     
     print(f"Generated {len(inp)} tasks after filtering")
     n_done = 0

--- a/analyze/count_patterns.py
+++ b/analyze/count_patterns.py
@@ -51,6 +51,9 @@ MAX_MATCHES_PER_QUERY = 10000
 DEFAULT_SAMPLE_ANCHORS = 1000
 CHECKPOINT_INTERVAL = 100  # Save progress every 100 tasks
 
+import multiprocessing as mp
+mp.set_start_method("spawn", force=True)
+
 def compute_graph_stats(G, args):
     """Compute graph statistics for filtering."""
     stats = {

--- a/common/utils.py
+++ b/common/utils.py
@@ -47,7 +47,10 @@ def sample_neigh(graphs, size):
             assert new_node not in neigh
             neigh.append(new_node)
             visited.add(new_node)
-            frontier += list(graph.neighbors(new_node))
+            if graph_type == "undirected":
+                frontier += list(graph.neighbors(new_node))
+            elif graph_type == "directed":
+                frontier += list(graph.successors(new_node))
             frontier = [x for x in frontier if x not in visited]
         if len(neigh) == size:
             return graph, neigh

--- a/common/utils.py
+++ b/common/utils.py
@@ -241,18 +241,22 @@ def build_optimizer(args, params):
 def standardize_graph(graph: nx.Graph, anchor: int = None) -> nx.Graph:
     """
     Standardize graph attributes to ensure compatibility with DeepSnap.
+    Handles both undirected and directed NetworkX graphs.
     
     Args:
-        graph: Input NetworkX graph
+        graph: Input NetworkX graph (can be nx.Graph or nx.DiGraph)
         anchor: Optional anchor node index
         
     Returns:
         NetworkX graph with standardized attributes
     """
-    g = nx.Graph()
+    # Detect graph type and create the same type
+    if isinstance(graph, nx.DiGraph):
+        g = nx.DiGraph()
+    else:
+        g = nx.Graph()
     g.add_nodes_from(graph.nodes())
     g.add_edges_from(graph.edges())
-   # g = graph.copy()
     
     # Standardize edge attributes
     for u, v in g.edges():
@@ -288,7 +292,6 @@ def standardize_graph(graph: nx.Graph, anchor: int = None) -> nx.Graph:
         if anchor is not None:
             node_data['node_feature'] = torch.tensor([float(node == anchor)])
         elif 'node_feature' not in node_data:
-            # Default feature if no anchor specified
             node_data['node_feature'] = torch.tensor([1.0])
             
         # Ensure label exists

--- a/common/utils.py
+++ b/common/utils.py
@@ -16,17 +16,16 @@ import warnings
 
 from common import feature_preprocess
 
-import argparse
-from subgraph_mining.config import parse_decoder
-from subgraph_matching.config import parse_encoder
+# import argparse
+# from subgraph_mining.config import parse_decoder
+# from subgraph_matching.config import parse_encoder
 
-utils_parser = argparse.ArgumentParser(description='Decoder arguments')
-parse_encoder(utils_parser)
-parse_decoder(utils_parser)
-utils_args = utils_parser.parse_args()
+# utils_parser = argparse.ArgumentParser(description='Decoder arguments')
+# parse_encoder(utils_parser)
+# parse_decoder(utils_parser)
+# utils_args = utils_parser.parse_args()
 
-def sample_neigh(graphs, size):
-    graph_type = utils_args.graph_type
+def sample_neigh(graphs, size, graph_type):
     ps = np.array([len(g) for g in graphs], dtype=float)
     ps /= np.sum(ps)
     dist = stats.rv_discrete(values=(np.arange(len(graphs)), ps))

--- a/common/utils.py
+++ b/common/utils.py
@@ -26,6 +26,7 @@ parse_decoder(parser)
 args = parser.parse_args()
 
 def sample_neigh(graphs, size):
+    graph_type = args.graph_type
     ps = np.array([len(g) for g in graphs], dtype=float)
     ps /= np.sum(ps)
     dist = stats.rv_discrete(values=(np.arange(len(graphs)), ps))
@@ -35,7 +36,10 @@ def sample_neigh(graphs, size):
         graph = graphs[idx]
         start_node = random.choice(list(graph.nodes))
         neigh = [start_node]
-        frontier = list(set(graph.neighbors(start_node)) - set(neigh))
+        if graph_type == "undirected":
+            frontier = list(set(graph.neighbors(start_node)) - set(neigh))
+        elif graph_type == "directed":
+            frontier = list(set(graph.successors(start_node)) - set(neigh))
         visited = set([start_node])
         while len(neigh) < size and frontier:
             new_node = random.choice(list(frontier))

--- a/common/utils.py
+++ b/common/utils.py
@@ -20,13 +20,13 @@ import argparse
 from subgraph_mining.config import parse_decoder
 from subgraph_matching.config import parse_encoder
 
-parser = argparse.ArgumentParser(description='Decoder arguments')
-parse_encoder(parser)
-parse_decoder(parser)
-args = parser.parse_args()
+utils_parser = argparse.ArgumentParser(description='Decoder arguments')
+parse_encoder(utils_parser)
+parse_decoder(utils_parser)
+utils_args = utils_parser.parse_args()
 
 def sample_neigh(graphs, size):
-    graph_type = args.graph_type
+    graph_type = utils_args.graph_type
     ps = np.array([len(g) for g in graphs], dtype=float)
     ps /= np.sum(ps)
     dist = stats.rv_discrete(values=(np.arange(len(graphs)), ps))

--- a/common/utils.py
+++ b/common/utils.py
@@ -16,6 +16,14 @@ import warnings
 
 from common import feature_preprocess
 
+import argparse
+from subgraph_mining.config import parse_decoder
+from subgraph_matching.config import parse_encoder
+
+parser = argparse.ArgumentParser(description='Decoder arguments')
+parse_encoder(parser)
+parse_decoder(parser)
+args = parser.parse_args()
 
 def sample_neigh(graphs, size):
     ps = np.array([len(g) for g in graphs], dtype=float)

--- a/subgraph_mining/config.py
+++ b/subgraph_mining/config.py
@@ -50,6 +50,10 @@ def parse_decoder(parser):
         help='Motif dataset to use')
     dec_parser.add_argument('--n_clusters', type=int,
         help='number of clusters for analysis')
+    
+        # Graph type selection
+    dec_parser.add_argument('--graph_type', type=str,
+        help='"directed" or "undirected" graph type')
 
     # Set default values
     parser.set_defaults(
@@ -65,6 +69,7 @@ def parse_decoder(parser):
         radius=3,
         subgraph_sample_size=0,
         sample_method="radial",
+        graph_type="undirected",
         skip="learnable",
         min_pattern_size=5,
         max_pattern_size=10,

--- a/subgraph_mining/decoder.py
+++ b/subgraph_mining/decoder.py
@@ -233,7 +233,7 @@ def pattern_growth(dataset, task, args):
             for j in tqdm(range(args.n_neighborhoods)):
                 graph, neigh = utils.sample_neigh(graphs,
                     random.randint(args.min_neighborhood_size,
-                        args.max_neighborhood_size))
+                        args.max_neighborhood_size), args.graph_type)
                 neigh = graph.subgraph(neigh)
                 neigh = nx.convert_node_labels_to_integers(neigh)
                 neigh.add_edge(0, 0)

--- a/subgraph_mining/search_agents.py
+++ b/subgraph_mining/search_agents.py
@@ -298,7 +298,10 @@ def run_greedy_trial(trial_idx):
     start_node = random.choice(list(graph.nodes))
 
     neigh = [start_node]
-    frontier = list(set(graph.neighbors(start_node)) - set(neigh))
+    if worker_args.graph_type == "undirected":
+        frontier = list(set(graph.neighbors(start_node)) - set(neigh))
+    elif worker_args.graph_type == "directed":
+        frontier = list(set(graph.successors(start_node)) - set(neigh))
     visited = {start_node}
 
     trial_patterns = defaultdict(list)

--- a/subgraph_mining/search_agents.py
+++ b/subgraph_mining/search_agents.py
@@ -343,7 +343,11 @@ def run_greedy_trial(trial_idx):
         if best_node is None:
             break
 
-        frontier = list(((set(frontier) | set(graph.neighbors(best_node))) - visited) - {best_node})
+        if worker_args.graph_type == "undirected":
+            frontier = list(((set(frontier) | set(graph.neighbors(best_node))) - visited) - {best_node})
+        elif worker_args.graph_type == "directed":
+            frontier = list(((set(frontier) | set(graph.successors(best_node))) - visited) - {best_node})
+            
         visited.add(best_node)
         neigh.append(best_node)
 


### PR DESCRIPTION
---

#### 1. **In `subgraph_miner/config.py`**:

* **Added `graph_type` argument** to the decoder parser to allow specifying `"directed"` or `"undirected"` graph processing.

  * **Lines 55–56**:

    ```python
    dec_parser.add_argument('--graph_type', type=str, help='"directed" or "undirected" graph type')
    ```
  * **Line 72**:

    ```python
    graph_type="undirected"
    ```

---

#### 2. **In `subgraph_miner/search_agents.py`**:

* **Used `graph.successors()`** if graph type is directed.

  * **Lines 303–304**:

    ```python
    elif worker_args.graph_type == "directed":
        frontier = list(set(graph.successors(start_node)) - set(neigh))
    ```
  * **Lines 348–349**:

    ```python
    elif worker_args.graph_type == "directed":
        frontier = list(((set(frontier) | set(graph.successors(best_node))) - visited) - {best_node})
    ```

---

#### 3. **In `common/utils.py`**:

* **Parsed `graph_type` from arguments**:

  * **Lines 23–26**:

    ```python
    parser = argparse.ArgumentParser(description='Decoder arguments')
    parse_encoder(parser)
    parse_decoder(parser)
    args = parser.parse_args()
    ```
* **Used `graph.successors()`** if graph type is directed:

  * **Lines 41–42**:

    ```python
    elif graph_type == "directed":
        frontier = list(set(graph.successors(start_node)) - set(neigh))
    ```
  * **Lines 52–53**:

    ```python
    elif graph_type == "directed":
        frontier += list(graph.successors(new_node))
    ```

---

#### 4. **In `analyze/count_patterns.py`**:

* **Parsed `graph_type` argument** using the config parsers:

  * **Lines 46–53**:

    ```python
    import argparse
    from subgraph_mining.config import parse_decoder
    from subgraph_matching.config import parse_encoder

    parser = argparse.ArgumentParser(description='Decoder arguments')
    parse_encoder(parser)
    parse_decoder(parser)
    args = parser.parse_args()
    ```

* **Used `number_strongly_connected_components()`** for directed graphs:

  * **Lines 72–73**:

    ```python
    if args.graph_type == "directed":
        stats['n_components'] = nx.number_strongly_connected_components(G)
    ```
  * **Lines 474–475**:

    ```python
    if args.graph_type == "directed":
        largest_cc = max(nx.strongly_connected_components(subgraph), key=len)
    ```

* **Created `DiGraph` if type is `"directed"`**:

  * **Lines 130–131**:

    ```python
    if args.graph_type == "directed":
        graph = nx.DiGraph()
    ```

* **Used `DiGraphMatcher` instead of `GraphMatcher`**:

  * **Lines 204–205**:

    ```python
    if args.graph_type == "directed":
        matcher = iso.DiGraphMatcher(target, query,
    ```
  * **Lines 215–216**:

    ```python
    if args.graph_type == "directed":
        matcher = iso.DiGraphMatcher(target, query,
    ```

* **Used `successors()` for traversals in directed graphs**:

  * **Lines 303–304**:

    ```python
    if args.graph_type == "directed":
        frontier = list(target.successors(start_node))
    ```
  * **Lines 313–314**:

    ```python
    if args.graph_type == "directed":
        frontier.extend([n for n in target.successors(next_node)
    ```
  * **Lines 486–487**:

    ```python
    if args.graph_type == "directed":
        frontier = list(set(graph.successors(start_node)) - set(neigh))
    ```
  * **Lines 493–494**:

    ```python
    if args.graph_type == "directed":
        frontier += list(graph.successors(new_node))
    ```

* **Converted to undirected if not a `DiGraph`**:

  * **Line 509**:

    ```python
    if isinstance(graph, nx.Graph) or isinstance(graph, nx.DiGraph):
    ```

---