### PR TITLE
fix the visualization to use the sampling anchor

### DIFF
--- a/subgraph_mining/decoder.py
+++ b/subgraph_mining/decoder.py
@@ -224,6 +224,7 @@ def pattern_growth(dataset, task, args):
                             subgraph.edges[mapping[old_u], mapping[old_v]].update(attrs)
                         
                         subgraph.add_edge(0, 0)
+                        neigh.nodes[0]["anchor"] = True
                         neighs.append(subgraph)
                         if args.node_anchored:
                             anchors.append(0)
@@ -236,6 +237,7 @@ def pattern_growth(dataset, task, args):
                 neigh = graph.subgraph(neigh)
                 neigh = nx.convert_node_labels_to_integers(neigh)
                 neigh.add_edge(0, 0)
+                neigh.nodes[0]["anchor"] = True
                 neighs.append(neigh)
                 if args.node_anchored:
                     anchors.append(0)
@@ -315,7 +317,7 @@ def pattern_growth(dataset, task, args):
                 for i, node in enumerate(pattern.nodes()):
                     node_label = pattern.nodes[node].get('label', 'unknown')
                     
-                    if args.node_anchored and i == 0:
+                    if args.node_anchored and pattern.nodes[node].get("anchor", False):
                         colors.append('red')
                         node_sizes.append(5000)
                         node_shapes.append('s')  

--- a/subgraph_mining/decoder.py
+++ b/subgraph_mining/decoder.py
@@ -224,7 +224,7 @@ def pattern_growth(dataset, task, args):
                             subgraph.edges[mapping[old_u], mapping[old_v]].update(attrs)
                         
                         subgraph.add_edge(0, 0)
-                        neigh.nodes[0]["anchor"] = True
+                        subgraph.nodes[0]["anchor"] = True
                         neighs.append(subgraph)
                         if args.node_anchored:
                             anchors.append(0)


### PR DESCRIPTION
# Description

- Added "anchor": True to the root node (index 0) during tree sampling after relabeling, ensuring the anchor attribute is preserved.
- Updated the visualization logic to identify the anchor node using pattern.nodes[node].get("anchor", False) and render it with a distinct style (red color, square shape).
- Kept all existing tree and radial sampling logic unchanged, modifying only the visualization and attribute handling to improve clarity.

# Reason

The visualization previously could not differentiate the anchor node because the "anchor" attribute was removed during node relabeling in the tree sampling process.
This PR restores the attribute and updates the drawing code so the anchor node is consistently and correctly highlighted.