### PR TITLE
Add Support for Directed Graphs in Subgraph Miner (NEW)

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -17,7 +17,7 @@ import warnings
 from common import feature_preprocess
 
 
-def sample_neigh(graphs, size):
+def sample_neigh(graphs, size, graph_type):
     ps = np.array([len(g) for g in graphs], dtype=float)
     ps /= np.sum(ps)
     dist = stats.rv_discrete(values=(np.arange(len(graphs)), ps))
@@ -27,7 +27,10 @@ def sample_neigh(graphs, size):
         graph = graphs[idx]
         start_node = random.choice(list(graph.nodes))
         neigh = [start_node]
-        frontier = list(set(graph.neighbors(start_node)) - set(neigh))
+        if graph_type == "undirected":
+            frontier = list(set(graph.neighbors(start_node)) - set(neigh))
+        elif graph_type == "directed":
+            frontier = list(set(graph.successors(start_node)) - set(neigh))
         visited = set([start_node])
         while len(neigh) < size and frontier:
             new_node = random.choice(list(frontier))

--- a/common/utils.py
+++ b/common/utils.py
@@ -156,7 +156,7 @@ def gen_baseline_queries_mfinder(queries, targets, n_samples=10000,
         print(size)
         counts = defaultdict(list)
         for i in tqdm(range(n_samples)):
-            graph, neigh = sample_neigh(targets, size)
+            graph, neigh = sample_neigh(targets, size, graph_type="undirected")
             v = neigh[0]
             neigh = graph.subgraph(neigh).copy()
             nx.set_node_attributes(neigh, 0, name="anchor")
@@ -244,7 +244,7 @@ def standardize_graph(graph: nx.Graph, anchor: int = None) -> nx.Graph:
         g = nx.DiGraph()
     else:
         g = nx.Graph()
-        
+
     g.add_nodes_from(graph.nodes())
     g.add_edges_from(graph.edges())
    # g = graph.copy()

--- a/common/utils.py
+++ b/common/utils.py
@@ -38,7 +38,10 @@ def sample_neigh(graphs, size, graph_type):
             assert new_node not in neigh
             neigh.append(new_node)
             visited.add(new_node)
-            frontier += list(graph.neighbors(new_node))
+            if graph_type == "undirected":
+                frontier += list(graph.neighbors(new_node))
+            elif graph_type == "directed":
+                frontier += list(graph.successors(new_node))
             frontier = [x for x in frontier if x not in visited]
         if len(neigh) == size:
             return graph, neigh

--- a/common/utils.py
+++ b/common/utils.py
@@ -240,7 +240,11 @@ def standardize_graph(graph: nx.Graph, anchor: int = None) -> nx.Graph:
     Returns:
         NetworkX graph with standardized attributes
     """
-    g = nx.Graph()
+    if isinstance(graph, nx.DiGraph):
+        g = nx.DiGraph()
+    else:
+        g = nx.Graph()
+        
     g.add_nodes_from(graph.nodes())
     g.add_edges_from(graph.edges())
    # g = graph.copy()

--- a/subgraph_mining/config.py
+++ b/subgraph_mining/config.py
@@ -68,7 +68,7 @@ def parse_decoder(parser):
         decode_thresh=0.5,
         radius=3,
         subgraph_sample_size=0,
-        sample_method="radial",
+        sample_method="tree",
         skip="learnable",
         graph_type="undirected",
         min_pattern_size=5,

--- a/subgraph_mining/config.py
+++ b/subgraph_mining/config.py
@@ -51,6 +51,10 @@ def parse_decoder(parser):
     dec_parser.add_argument('--n_clusters', type=int,
         help='number of clusters for analysis')
 
+    # Graph type selection
+    dec_parser.add_argument('--graph_type', type=str,
+        help='"directed" or "undirected" graph type')
+    
     # Set default values
     parser.set_defaults(
         # Dataset defaults
@@ -66,6 +70,7 @@ def parse_decoder(parser):
         subgraph_sample_size=0,
         sample_method="radial",
         skip="learnable",
+        graph_type="undirected",
         min_pattern_size=5,
         max_pattern_size=10,
         min_neighborhood_size=5,

--- a/subgraph_mining/decoder.py
+++ b/subgraph_mining/decoder.py
@@ -525,7 +525,7 @@ def pattern_growth(dataset, task, args):
             for j in tqdm(range(args.n_neighborhoods)):
                 graph, neigh = utils.sample_neigh(graphs,
                     random.randint(args.min_neighborhood_size,
-                        args.max_neighborhood_size))
+                        args.max_neighborhood_size), args.graph_type)
                 neigh = graph.subgraph(neigh)
                 neigh = nx.convert_node_labels_to_integers(neigh)
                 neigh.add_edge(0, 0)

--- a/subgraph_mining/search_agents.py
+++ b/subgraph_mining/search_agents.py
@@ -298,7 +298,10 @@ def run_greedy_trial(trial_idx):
     start_node = random.choice(list(graph.nodes))
 
     neigh = [start_node]
-    frontier = list(set(graph.neighbors(start_node)) - set(neigh))
+    if worker_args.graph_type == "undirected":
+        frontier = list(set(graph.neighbors(start_node)) - set(neigh))
+    elif worker_args.graph_type == "directed":
+        frontier = list(set(graph.successors(start_node)) - set(neigh))
     visited = {start_node}
 
     trial_patterns = defaultdict(list)

--- a/subgraph_mining/search_agents.py
+++ b/subgraph_mining/search_agents.py
@@ -343,7 +343,11 @@ def run_greedy_trial(trial_idx):
         if best_node is None:
             break
 
-        frontier = list(((set(frontier) | set(graph.neighbors(best_node))) - visited) - {best_node})
+        if worker_args.graph_type == "undirected":
+            frontier = list(((set(frontier) | set(graph.neighbors(best_node))) - visited) - {best_node})
+        elif worker_args.graph_type == "directed":
+            frontier = list(((set(frontier) | set(graph.successors(best_node))) - visited) - {best_node})      
+              
         visited.add(best_node)
         neigh.append(best_node)
 


### PR DESCRIPTION
---

#### 1. **In `subgraph_miner/config.py`**:

* **Added `graph_type` argument** to the decoder parser to allow specifying `"directed"` or `"undirected"` graph processing.

  * **Lines 55–56**:

    ```python
    dec_parser.add_argument('--graph_type', type=str, help='"directed" or "undirected" graph type')
    ```
  * **Line 72**:

    ```python
    graph_type="undirected"
    ```

---

#### 2. **In `subgraph_miner/search_agents.py`**:

* **Used `graph.successors()`** if graph type is directed.

  * **Lines 303–304**:

    ```python
    elif worker_args.graph_type == "directed":
        frontier = list(set(graph.successors(start_node)) - set(neigh))
    ```
  * **Lines 348–349**:

    ```python
    elif worker_args.graph_type == "directed":
        frontier = list(((set(frontier) | set(graph.successors(best_node))) - visited) - {best_node})
    ```

---

#### 3. **In `common/utils.py`**:

* **Add `graph_type` to `sample_neigh` definition**:

  * **Lines 20**:

    ```python
       def sample_neigh(graphs, size, graph_type):
    ```
* **Used `graph.successors()`** if graph type is directed:

  * **Lines 31–33**:

    ```python
    elif graph_type == "directed":
        frontier = list(set(graph.successors(start_node)) - set(neigh))
    ```
  * **Lines 43–44**:

    ```python
    elif graph_type == "directed":
        frontier += list(graph.successors(new_node))
    ```

---

---

#### 3. **In `subgraph_mining/decoder.py`**:

* **Add `graph_type` to `sample_neigh` call**:

  * **Lines 526 - 528**:

    ```python
       graph, neigh = utils.sample_neigh(graphs,
                    random.randint(args.min_neighborhood_size,
                        args.max_neighborhood_size), args.graph_type)
    ```

---