### PR TITLE
Updated GitHub workflow to use prebuilt Docker image

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -14,30 +14,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-      - name: Build Docker image
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          load: true
-          tags: decoder-image:latest
-          cache-from: |
-            type=local,src=/tmp/.buildx-cache
-          cache-to: |
-            type=local,dest=/tmp/.buildx-cache-new,mode=max
-      - name: Move cache
+      # Pull prebuilt Docker image from Docker Hub
+      - name: Pull prebuilt Docker image
         run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          echo "${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}" | docker login -u samribahta --password-stdin
+          docker pull samribahta/decoder-image:latest
       - name: Create output directories
         run: |
           mkdir -p ${{ github.workspace }}/plots/cluster
@@ -55,17 +36,18 @@ jobs:
           echo "Percent of processors used: ${PERCENT_USED}%"
           echo "total_cpus=$TOTAL_CPUS" >> $GITHUB_OUTPUT
           echo "percent_used=$PERCENT_USED" >> $GITHUB_OUTPUT
+      #  Run decoder using prebuilt Docker image
       - name: Run decoder in Docker container
         run: |
           docker run --rm \
             -v ${{ github.workspace }}:/app \
             -e PYTHONUNBUFFERED=1 \
-            decoder-image:latest \
+            samribahta/decoder-image:latest \
             bash -c "
               set -e
               echo 'Starting decoder run...'
               python -m subgraph_mining.decoder \
-                --dataset=metta.pkl \
+                --dataset=directed.pkl \
                 --n_trials=200 \
                 --node_anchored \
                 --out_path=/app/results/patterns.pkl \
@@ -73,13 +55,13 @@ jobs:
               echo 'Checking output directories...'
               ls -la /app/plots/cluster
               ls -la /app/results
-              "
+            "
       # - name: Run pattern counter in Docker container
       #   run: |
       #     docker run --rm \
       #       -v ${{ github.workspace }}:/app \
       #       -e PYTHONUNBUFFERED=1 \
-      #       decoder-image:latest \
+      #       samribahta/decoder-image:latest \
       #       bash -c "
       #         set -e
       #         export PYTHONPATH=/app
@@ -94,24 +76,24 @@ jobs:
       #         ls -la /app/results
       #       "
       # - name: Run matcher in Docker container
-      #  run: |
-      #   docker run --rm \
-      #    -v ${{ github.workspace }}:/app \
-      #   -e PYTHONUNBUFFERED=1 \
-      #  decoder-image:latest \
-      # bash -c "
-      #  set -e
-      # echo 'Starting matcher run on custom gene graph...'
-      #ython -m subgraph_matching.train \
-      # --dataset=graph \
-      #--graph_pkl_path=graph.pkl \
-      #--node_anchored \
-      #--batch_size 16 \
-      #--val_size 128
-      #echo 'Checking output directories...'
-      #ls -la /app/results
-      # ls -la /app/plots
-      #"
+      #   run: |
+      #     docker run --rm \
+      #       -v ${{ github.workspace }}:/app \
+      #       -e PYTHONUNBUFFERED=1 \
+      #       samribahta/decoder-image:latest \
+      #       bash -c "
+      #         set -e
+      #         echo 'Starting matcher run on custom gene graph...'
+      #         python -m subgraph_matching.train \
+      #           --dataset=graph \
+      #           --graph_pkl_path=graph.pkl \
+      #           --node_anchored \
+      #           --batch_size 16 \
+      #           --val_size 128
+      #         echo 'Checking output directories...'
+      #         ls -la /app/results
+      #         ls -la /app/plots
+      #       "
       - name: Check for generated files
         run: |
           echo "Checking plots directory:"

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -17,7 +17,6 @@ jobs:
       # Pull prebuilt Docker image from Docker Hub
       - name: Pull prebuilt Docker image
         run: |
-          echo "${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}" | docker login -u samribahta --password-stdin
           docker pull samribahta/decoder-image:latest
       - name: Create output directories
         run: |


### PR DESCRIPTION


This PR updates the **Run Decoder** GitHub Actions workflow to use a **prebuilt Docker image** pulled from Docker Hub instead of building the image during workflow run.  

## 🔧 What Changed

### **Removed**
- Buildx setup  
- Docker image build step  
- All Docker layer caching steps  
- Local Buildx cache management

### **Added**
- Login to Docker Hub using `DOCKER_HUB_ACCESS_TOKEN`  
- Pulling prebuilt image:  
  ```bash
  docker pull samribahta/decoder-image:latest