### PR TITLE
Fix Docker build by switching to python:3.7-slim

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -55,6 +55,7 @@ jobs:
           echo "Percent of processors used: ${PERCENT_USED}%"
           echo "total_cpus=$TOTAL_CPUS" >> $GITHUB_OUTPUT
           echo "percent_used=$PERCENT_USED" >> $GITHUB_OUTPUT
+
       - name: Run decoder in Docker container
         run: |
           docker run --rm \
@@ -69,30 +70,32 @@ jobs:
                 --n_trials=200 \
                 --node_anchored \
                 --out_path=/app/results/patterns.pkl \
-                --graph_type=directed
+                
+
+
               echo 'Checking output directories...'
               ls -la /app/plots/cluster
               ls -la /app/results
               "
-      # - name: Run pattern counter in Docker container
-      #   run: |
-      #     docker run --rm \
-      #       -v ${{ github.workspace }}:/app \
-      #       -e PYTHONUNBUFFERED=1 \
-      #       decoder-image:latest \
-      #       bash -c "
-      #         set -e
-      #         export PYTHONPATH=/app
-      #         echo 'Running pattern counter...'
-      #         python -m analyze.count_patterns \
-      #           --dataset=graph.pkl \
-      #           --queries_path=results/patterns.pkl \
-      #           --out_path=results/ \
-      #           --node_anchored \
-      #           --preserve_labels
-      #         echo 'Counting completed.'
-      #         ls -la /app/results
-      #       "
+      - name: Run pattern counter in Docker container
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/app \
+            -e PYTHONUNBUFFERED=1 \
+            decoder-image:latest \
+            bash -c "
+              set -e
+              export PYTHONPATH=/app
+              echo 'Running pattern counter...'
+              python -m analyze.count_patterns \
+                --dataset=metta.pkl \
+                --queries_path=results/patterns.pkl \
+                --out_path=results/ \
+                --node_anchored \
+             
+              echo 'Counting completed.'
+              ls -la /app/results
+            "
       # - name: Run matcher in Docker container
       #  run: |
       #   docker run --rm \
@@ -112,6 +115,18 @@ jobs:
       #ls -la /app/results
       # ls -la /app/plots
       #"
+      #         echo 'Starting matcher run on custom gene graph...'
+      #         python -m subgraph_matching.train \
+      #           --dataset=graph \
+      #           --graph_pkl_path=graph.pkl \
+      #           --node_anchored \
+      #           --batch_size 16 \
+      #           --val_size 128
+      #         echo 'Checking output directories...'
+      #         ls -la /app/results
+      #         ls -la /app/plots
+      #       "
+
       - name: Check for generated files
         run: |
           echo "Checking plots directory:"

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -77,25 +77,25 @@ jobs:
               ls -la /app/plots/cluster
               ls -la /app/results
               "
-      - name: Run pattern counter in Docker container
-        run: |
-          docker run --rm \
-            -v ${{ github.workspace }}:/app \
-            -e PYTHONUNBUFFERED=1 \
-            decoder-image:latest \
-            bash -c "
-              set -e
-              export PYTHONPATH=/app
-              echo 'Running pattern counter...'
-              python -m analyze.count_patterns \
-                --dataset=metta.pkl \
-                --queries_path=results/patterns.pkl \
-                --out_path=results/ \
-                --node_anchored \
-             
-              echo 'Counting completed.'
-              ls -la /app/results
-            "
+      # - name: Run pattern counter in Docker container
+      #   run: |
+      #     docker run --rm \
+      #       -v ${{ github.workspace }}:/app \
+      #       -e PYTHONUNBUFFERED=1 \
+      #       decoder-image:latest \
+      #       bash -c "
+      #         set -e
+      #         export PYTHONPATH=/app
+      #         echo 'Running pattern counter...'
+      #         python -m analyze.count_patterns \
+      #           --dataset=metta.pkl \
+      #           --queries_path=results/patterns.pkl \
+      #           --out_path=results/ \
+      #           --node_anchored \
+
+      #         echo 'Counting completed.'
+      #         ls -la /app/results
+      #       "
       # - name: Run matcher in Docker container
       #  run: |
       #   docker run --rm \


### PR DESCRIPTION
# Description

This pull request updates the Docker environment to use a cleaner, more maintainable base image and simplifies the overall Python setup process.

# Changes

- Replaced the previous ubuntu:20.04–based image (which relied on manual Python 3.7 installation via deadsnakes PPA, get-pip.py, and custom symlinks) with the official python:3.7-slim base image.

- Streamlined the Python environment by using the built-in Python 3.7 and pip, installing only the necessary system dependencies (BLAS/LAPACK, igraph, SciPy, etc.) via apt.

- Preserved the existing Python package versions — including numpy 1.21.6, networkx 2.4, torch 1.4.0, torch-geometric 1.4.3, and deepsnap 0.1.2 — now installed on top of python:3.7-slim for a more stable and reproducible build.