### PR TITLE
Reduce Docker build context/storage size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,43 @@
+.git/
+.gitignore
+
+# Local env files
+.env
+.env.*
+
+# virtual envs
+env/
+venv/
+.venv/
+
+#  caches
+__pycache__/
+**/__pycache__/
+*.py[cod]
+*.pyd
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
+# Jupyter notebooks & its checkpoints 
+.ipynb_checkpoints/
+**/*.ipynb
+
+# Runtime/training outputs, wich aregenerated at runtime
+results/
+plots/
+runs/
+
+# Large datasets (API mode uploads graph files instead)
+data/
+
+# Common archives/logs
+*.log
+*.zip
+*.tar
+*.tar.gz
+*.tgz
+*.gz
+*.rar
+
+.vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@ FROM python:3.7-slim
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 
+# Make pip installs on slower networks
+ENV PIP_DEFAULT_TIMEOUT=300
+ENV PIP_NO_BUILD_ISOLATION=1
+
 # Install system build dependencies
 RUN apt-get update && apt-get install -y \
     build-essential \

--- a/common/utils.py
+++ b/common/utils.py
@@ -180,15 +180,6 @@ def gen_baseline_queries_mfinder(queries, targets, n_samples=10000,
             out.append(random.choice(neighs))
     return out
 
-device_cache = None
-def get_device():
-    global device_cache
-    if device_cache is None:
-        device_cache = torch.device("cuda") if torch.cuda.is_available() \
-            else torch.device("cpu")
-        #device_cache = torch.device("cpu")
-    return device_cache
-
 def parse_optimizer(parser):
     opt_parser = parser.add_argument_group()
     opt_parser.add_argument('--opt', dest='opt', type=str,


### PR DESCRIPTION
## Summary
This PR improves the Docker  build experience by shrinking the Docker build context/memory storage and making dependency installs more resilient on slow Internet. 

## What changed
- Added a .dockerignore to exclude large local artifacts (datasets, results/plots, runs, virtualenvs, caches) from the Docker build context/memory storage.
- Updated the Dockerfile to set pip environment variables to better tolerate slow-downloads/timeouts:
  - `PIP_DEFAULT_TIMEOUT=300`
  - `PIP_NO_BUILD_ISOLATION=1`
- Removed a duplicated `get_device()` method definition (the later one already overrode the earlier one at runtime), this reduces the confusion and keeping a single  implementation.

## Why It matters
Before this change, `docker build` was spending a long time transferring a huge GB build context/storage (I observed ~~ 4GB). But after I added .dockerignore , the build context decreases to ~~215MB, which significantly speeds up docker builds and reduces disk/network overhead.

## Testing: 
May check it out using the command below:
- `docker build -t neural-miner` , It would take only ~215MB build context size once this change integrated.
