### PR TITLE
Single-mode decoder + free main graph after neighborhoods

### DIFF
--- a/subgraph_mining/config.py
+++ b/subgraph_mining/config.py
@@ -62,8 +62,6 @@ def parse_decoder(parser):
     # Batch processing parameters
     dec_parser.add_argument('--streaming_workers', type=int, default=4,
         help='Number of workers for streaming. (Auto-scaled down for large graphs to prevent OOM)')
-    dec_parser.add_argument('--auto_streaming_threshold', type=int, default=500000,
-        help='Auto-enable batch processing for graphs with more than this many nodes')
 
     # Set default values
     parser.set_defaults(
@@ -90,5 +88,4 @@ def parse_decoder(parser):
         node_anchored=True,
         memory_limit=1000000,
         streaming_workers=4,
-        auto_streaming_threshold=50000
     )

--- a/subgraph_mining/decoder.py
+++ b/subgraph_mining/decoder.py
@@ -1132,7 +1132,13 @@ def pattern_growth(dataset, task, args, precomputed_data=None, preloaded_model=N
                 if 'id' not in graph.nodes[node]:
                     graph.nodes[node]['id'] = str(node)
         graphs.append(graph)
-    
+        
+    if isinstance(dataset, LazyNeighborhoodGraphList):
+        import gc
+        dataset.dataset_graph = None
+        gc.collect()
+        logger.info("Freed main graph from RAM (Fix 2); search phase uses only neighborhood list.")
+
     if args.use_whole_graphs:
         neighs = graphs
     else:


### PR DESCRIPTION
## Summary
- **Single mode:** Decoder always uses batch (streaming) processing for every graph. No threshold and no alternate "standard" path.
- **Memory :** After building the neighborhood list, the main graph is freed from RAM

## Changes
- **`subgraph_mining/decoder.py`:** Single code path that always calls `pattern_growth_streaming`; inside `pattern_growth`, when the dataset is a `LazyNeighborhoodGraphList`, set `dataset_graph = None` and run `gc.collect()` after materializing the neighborhood list.
- **`subgraph_mining/config.py`:** Removed deprecated `--auto_streaming_threshold` . 

